### PR TITLE
fixed Post.is_comment() returning True for some toplevel posts

### DIFF
--- a/steemtools/base.py
+++ b/steemtools/base.py
@@ -280,9 +280,6 @@ class Post(piston.steem.Post):
         super(Post, self).__init__(steem, post)
 
     def is_comment(self):
-        if self['permlink'][:3] == "re-":
-            return True
-
         if len(self['title']) == 0:
             return True
 


### PR DESCRIPTION
Hi @Netherdrake --
I believe these 3 lines should be removed. There are top level posts with permlinks starting with 're-', for example, https://steemit.com/steemit/@bkkshadow/re-posting-on-steemit-to-do-or-not-to-do
